### PR TITLE
Update hardhat-foundry-ci.yml

### DIFF
--- a/.github/workflows/hardhat-foundry-ci.yml
+++ b/.github/workflows/hardhat-foundry-ci.yml
@@ -26,16 +26,16 @@ concurrency:
 
 jobs:
   test_on_windows:
-    name: Test hardhat-foundry on Windows with Node 16
+    name: Test hardhat-foundry on Windows with Node 22
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
-      - uses: actions/setup-node@v2
+          version: 10
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -47,18 +47,18 @@ jobs:
         run: pnpm test
 
   test_on_macos:
-    name: Test hardhat-foundry on MacOS with Node 16
+    name: Test hardhat-foundry on MacOS with Node 22
     runs-on: macos-latest
     # disable until actions/virtual-environments#4896 is fixed
     if: ${{ false }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
-      - uses: actions/setup-node@v2
+          version: 10
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -74,13 +74,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [20, 22]
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
-      - uses: actions/setup-node@v2
+          version: 10
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Update the hardhat-foundry GitHub Actions workflow by upgrading action versions, bumping Node.js support to 22, and refining the Ubuntu test matrix.

Enhancements:
- Upgrade GitHub Actions steps in hardhat-foundry CI to use the latest checkout, pnpm, and setup-node actions

CI:
- Bump Node.js version to 22 for Windows and macOS jobs
- Adjust Ubuntu test matrix to run on Node.js 20 and 22