### PR TITLE
Update test-recent-mainnet-block.yml

### DIFF
--- a/.github/workflows/test-recent-mainnet-block.yml
+++ b/.github/workflows/test-recent-mainnet-block.yml
@@ -14,13 +14,13 @@ jobs:
     name: Test recent mainnet block
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: "pnpm"
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary by Sourcery

Update the test-recent-mainnet-block CI workflow to use the latest versions of GitHub Actions, PNPM, and Node.js.

CI:
- Upgrade actions/checkout to v4
- Upgrade pnpm/action-setup to v4 and bump PNPM version to 10
- Bump Node.js version from 16 to 22 in the workflow